### PR TITLE
fix: set the correct working-directory

### DIFF
--- a/deploy-techdocs/action.yaml
+++ b/deploy-techdocs/action.yaml
@@ -40,6 +40,7 @@ runs:
 
     - name: Generate docs site
       shell: bash
+      working-directory: "${{ inputs.working-directory }}"
       run: techdocs-cli generate --no-docker --verbose
 
     - name: Publish docs site


### PR DESCRIPTION
I missed something in my previous PR #7. This PR is setting the correct working-directory when generating the docs.